### PR TITLE
Webpack server, hot-loading

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node node_modules/.bin/webpack-dev-server --port 9090 --quiet --hot",
+    "start": "node server.js",
     "lint": "node node_modules/.bin/eslint -c .eslintrc src/**"
   },
   "repository": {
@@ -34,6 +34,7 @@
     "history": "^1.17.0",
     "react": "^0.14.5",
     "react-dom": "^0.14.5",
+    "react-hot-loader": "^1.3.0",
     "react-inline-css": "^2.0.1",
     "react-router": "^1.0.3"
   },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node server.js",
+    "start": "webpack && node server.js",
     "lint": "node node_modules/.bin/eslint -c .eslintrc src/**"
   },
   "repository": {

--- a/server.js
+++ b/server.js
@@ -14,4 +14,3 @@ new WebpackDevServer(webpack(config), {
   }
   console.log('webpack server running on ' + port)
 })
-

--- a/server.js
+++ b/server.js
@@ -1,0 +1,17 @@
+var webpack          = require('webpack')
+  , WebpackDevServer = require('webpack-dev-server')
+  , config           = require('./webpack.config')
+  , port             = 9090
+
+new WebpackDevServer(webpack(config), {
+  publicPath: config.output.publicPath
+, hot: true
+, quiet: true
+, historyApiFallback: true
+}).listen(port, 'localhost', function(err, result){
+  if (err){
+    console.log(err)
+  }
+  console.log('webpack server running on ' + port)
+})
+

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,11 @@ var React   = require('react')
   , webpack = require('webpack')
 
 module.exports = {
-  entry: './src/index.jsx',
+  entry: [
+    'webpack-dev-server/client?http://0.0.0.0:9090'
+  , 'webpack/hot/only-dev-server'
+  , './src/index.jsx'
+  ],
   output: {
     filename: 'bundle.js',
     path: path.join(__dirname, 'public'),
@@ -13,7 +17,7 @@ module.exports = {
     loaders: [{
         test: /\.jsx$/,
         exclude: /node_modules/,
-        loaders: ['babel']
+        loaders: ['react-hot', 'babel']
       },
       {
         test: /\.less$/,
@@ -22,6 +26,9 @@ module.exports = {
       }
     ]
   },
+  plugins: [
+    new webpack.HotModuleReplacementPlugin()
+  ],
   resolve: {
     extensions: ['', '.js', '.jsx']
   }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = {
   output: {
     filename: 'bundle.js',
     path: path.join(__dirname, 'public'),
-    publicPath: 'public'
+    publicPath: '/'
   },
   module: {
     loaders: [{


### PR DESCRIPTION
Separate webpack server file, changes to NPM scripts to reflect this.

Added hot-loading with react-hot-loader--it's 'deprecated' and its author now wrote/uses react-transform-hmr, but we'd had trouble getting hmr to work, and seems to be less community support/activity around it.
