### PR TITLE
Npm start

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,9 @@ We're a group of students at [DevMountain](https://github.com/devmountain), buil
 
 Well, that's what we imagined, because right now there's a ton of tooling around Javascript development, but not nearly enough tools for teaching it. We're starting with a React-based student app and a package for one of the most popular editors on the market. We hope to build this into something pretty awesome, because no one should have to use JSBin, Github, and Slack, just to get through one lecture.
 
-For now, please check out our code. PRs welcome.
+This is the front end for our tool, built in React, using Firepad. To get started, `git clone
+https://github.com/pharaoh-js/pharaoh.git`, `cd pharaoh`, `npm i`,  and `npm start`. If you have problems with
+webpack-dev-server's process not dying on `ctrl+c`, use `npm run go` instead.
+
+All PRs welcome!
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
+    "run": "npm-start",
     "start": "webpack-dev-server --noInfo --port 9090 --hot --inline --open",
     "lint": "node node_modules/.bin/eslint -c .eslintrc src/**"
   },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "run": "npm-start",
+    "go": "npm-start",
     "start": "webpack-dev-server --noInfo --port 9090 --hot --inline --open",
     "lint": "node node_modules/.bin/eslint -c .eslintrc src/**"
   },

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "firebase": "^2.3.2",
     "firepad": "^1.3.0",
     "history": "^1.17.0",
+    "npm-start": "^1.4.2",
     "react": "^0.14.5",
     "react-dom": "^0.14.5",
     "react-fontawesome": "^0.3.3",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,14 +5,14 @@ var React   = require('react')
 module.exports = {
   devtool: 'cheap-module-eval-source-map'
 , entry: [
-    'webpack-dev-server/client?http://0.0.0.0:9090'
+    'webpack-dev-server/client?http://127.0.0.1:9090'
   , 'webpack/hot/only-dev-server'
   , './src/index.jsx'
   ],
   output: {
     filename: 'bundle.js'
   , sourceMapFilename: "[file].map"
-  , publicPath: 'http://0.0.0.0:9090/public'
+  , publicPath: 'http://127.0.0.1:9090/public'
   },
   module: {
     loaders: [{


### PR DESCRIPTION
Added the Bash script `npm start`; now, running the app with `npm run go` will use `npm-start` to run the command `npm run-scripts start` (`npm start`); for environments where `ctrl-c` doesn't kill all child processes, this will be the way to go, I think.

Updated the readme with instructions about that.
